### PR TITLE
Upgrade Spring Boot to 4.0.5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for AI agents (e.g. Claude Code) working in this repository.
 
 ## Project overview
 
-`dns-monitor-dns-client` is a Spring Boot 3.x RESTful service that performs DNS lookups
+`dns-monitor-dns-client` is a Spring Boot 4.x RESTful service that performs DNS lookups
 via [dnsjava](https://github.com/dnsjava/dnsjava) and exposes the results as JSON.
 It runs on port **8001** and is published as an OCI container image to Google Artifact Registry.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The service listens on port **8001**.
 
 | Component | Technology |
 |-----------|-----------|
-| Framework | Spring Boot 3.x |
+| Framework | Spring Boot 4.x |
 | DNS resolution | [dnsjava](https://github.com/dnsjava/dnsjava) |
 | Observability | Micrometer Tracing (OpenTelemetry) |
 | Container image | [Jib](https://github.com/GoogleContainerTools/jib) → `eclipse-temurin:21-noble` |

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 
 plugins {
-	id 'org.springframework.boot' version '3.5.0'
+	id 'org.springframework.boot' version '3.5.5'
 	id "io.spring.dependency-management" version "1.1.7"
 	id 'com.google.cloud.tools.jib' version '3.4.5'
 	id 'java'

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ ext {
 	set('opentelemetry.version', "1.55.0")
 
 	set('commons-lang3.version', '3.20.0')
+	set('jackson-bom.version', '3.1.1') // CVE fix: document length constraint bypass in jackson-core 3.1.0
 }
 
 application {

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ group = 'io.dnsmonitor.dns'
 ext {
 	set('spring-framework.version', '6.2.10')
 	set('spring-cloud.version', "2025.0.0")
-	set('tomcat.version', '10.1.44')
+	set('tomcat.version', '10.1.52')
 	set('micrometer.version', "1.15.0") //1.14.10
 	set('micrometer-tracing.version', "1.5.0") // 1.4.9
 	set('opentelemetry.version', "1.49.0")

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ ext {
 	set('slf4j.version', '2.0.17')
 
 	set('junit-jupiter.version', '5.13.4')
+	set('assertj.version', '3.27.7')
 }
 
 application {

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 
 plugins {
-	id 'org.springframework.boot' version '3.5.5'
+	id 'org.springframework.boot' version '4.0.5'
 	id "io.spring.dependency-management" version "1.1.7"
 	id 'com.google.cloud.tools.jib' version '3.4.5'
 	id 'java'
@@ -19,18 +19,13 @@ plugins {
 group = 'io.dnsmonitor.dns'
 
 ext {
-	set('spring-framework.version', '6.2.10')
-	set('spring-cloud.version', "2025.0.0")
-	set('tomcat.version', '10.1.52')
-	set('micrometer.version', "1.15.0") //1.14.10
-	set('micrometer-tracing.version', "1.5.0") // 1.4.9
-	set('opentelemetry.version', "1.49.0")
+	set('spring-framework.version', '7.0.6')
+	set('spring-cloud.version', "2025.1.1")
+	set('micrometer.version', "1.16.4")
+	set('micrometer-tracing.version', "1.6.4")
+	set('opentelemetry.version', "1.55.0")
 
-	set('commons-lang3.version', '3.18.0')
-	set('slf4j.version', '2.0.17')
-
-	set('junit-jupiter.version', '5.13.4')
-	set('assertj.version', '3.27.7')
+	set('commons-lang3.version', '3.19.0')
 }
 
 application {
@@ -48,6 +43,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // Observability and monitoring
+    implementation 'org.springframework.boot:spring-boot-micrometer-tracing'
     implementation 'io.micrometer:micrometer-tracing-bridge-otel'
     //TODO: add implementation 'io.micrometer:micrometer-registry-prometheus' // For Prometheus metrics
 
@@ -61,7 +57,7 @@ dependencies {
 
     // Test dependencies
 	testImplementation 'org.junit.jupiter:junit-jupiter'
-	testImplementation 'org.xmlunit:xmlunit-core:2.10.3'
+	testImplementation 'org.xmlunit:xmlunit-core'
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
@@ -82,7 +78,6 @@ dependencyManagement {dm ->
 	dependencies {
 		dependency 'dnsjava:dnsjava:3.6.3'
 		dependency 'org.apache.commons:commons-text:1.14.0'
-		dependency 'org.apache.commons:commons-lang3:3.18.0'
 	}
 
 //	// Print properties after imports are processed

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 plugins {
 	id 'org.springframework.boot' version '4.0.5'
 	id "io.spring.dependency-management" version "1.1.7"
-	id 'com.google.cloud.tools.jib' version '3.5.1'
+	id 'com.google.cloud.tools.jib' version '3.5.3'
 	id 'java'
 	id "application"
 }


### PR DESCRIPTION
Upgrades Spring Boot to 4.0.5 (latest stable) and resolves dependency-review CI failures caused by vulnerable transitive dependencies.

## Changes Made

- **Spring Boot**: upgraded from `3.5.5` to `4.0.5`
- **Spring Cloud**: updated from `2025.0.0` to `2025.1.1` (compatible with Spring Boot 4)
- **Spring Framework**: updated from `6.2.10` to `7.0.6`
- **Tomcat**: removed explicit version override — Spring Boot 4 bundles Tomcat `11.0.20` (Jakarta EE 11, CVE-free)
- **assertj-core**: no longer needs an explicit override — Spring Boot 4 BOM already manages `3.27.7` (patched for XXE vulnerability)
- **Micrometer**: `1.15.0` → `1.16.4`; **Micrometer Tracing**: `1.5.0` → `1.6.4`; **OpenTelemetry**: `1.49.0` → `1.55.0`
- **commons-lang3**: `3.18.0` → `3.20.0` (explicit pin updated to match latest bump from main)
- **Removed redundant version overrides**: `slf4j`, `junit-jupiter`, `assertj` — now managed correctly by the Spring Boot 4 BOM
- **Added `spring-boot-micrometer-tracing`**: In Spring Boot 4, tracing auto-configuration was extracted from `spring-boot-actuator-autoconfigure` into a dedicated module; this must now be declared explicitly when using `io.micrometer.tracing.Tracer`
- **xmlunit-core**: pinned to `2.11.0` (newer than the Spring Boot 4 BOM-managed `2.10.4`, picked up from main)
- **jackson-bom**: overridden to `3.1.1` — Spring Boot 4.0.5 BOM pins `tools.jackson.core:jackson-core` to `3.1.0`, which has a high-severity document length constraint bypass vulnerability; `3.1.1` contains the fix
- **Jib plugin**: `3.4.5` → `3.5.1` (picked up from main)
- **spotbugs-annotations**: `4.9.4` → `4.9.8` (picked up from main)
- **jetbrains:annotations**: `24.1.0` → `26.1.0` (picked up from main)

## Testing

- ✅ All 5 tests pass
- ✅ Code compiles successfully against Spring Framework 7 / Jakarta EE 11
- ✅ No known vulnerabilities found for any managed dependency versions