### PR TITLE
Update dependency review action

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           retry-on-snapshot-warnings: true
           retry-on-snapshot-warnings-timeout: 600


### PR DESCRIPTION
## Summary
- update actions/dependency-review-action from v4 to v5
- keep workflows on current major action pins; no setup-node/node-version entries are present

## Validation
- git diff --check