### PR TITLE
chore(gradle): use assignment syntax for maven repository urls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
 	repositories {
-		maven { url "https://plugins.gradle.org/m2/" }
-		maven { url "https://repo.spring.io/libs-release/" }
+		maven { url = uri("https://plugins.gradle.org/m2/") }
+		maven { url = uri("https://repo.spring.io/libs-release/") }
 		mavenCentral()
-		maven { url "https://repo.spring.io/milestone/" }
-		maven { url "https://ajoberstar.org/bintray-backup/" }
+		maven { url = uri("https://repo.spring.io/milestone/") }
+		maven { url = uri("https://ajoberstar.org/bintray-backup/") }
 	}
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,9 +19,9 @@ reckon {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
-        maven { url "https://repo.spring.io/libs-release" }
+        maven { url = uri("https://repo.spring.io/libs-release") }
         mavenCentral()
-        maven { url "https://repo.spring.io/milestone/" }
+        maven { url = uri("https://repo.spring.io/milestone/") }
         //google()
     }
 }


### PR DESCRIPTION
Replace the deprecated `maven { url "..." }` Groovy-DSL form with `maven { url = uri("...") }` in both buildscript and project repositories. The old form is scheduled to be removed in Gradle 10 and currently emits deprecation warnings on every configuration (`./gradlew help --warning-mode all` -> 0 matches after this change).

No behaviour change.

Refs the Gradle 10 compatibility assessment: the next blocker is the Reckon plugin, which is unmaintained.