### PR TITLE
build: enable Gradle build cache and configuration cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,18 @@ produce. To override the resolved version when cutting a release:
 
 `release` is restricted to the `main` branch.
 
+## Gradle build performance
+
+`gradle.properties` enables the Gradle build cache and the configuration cache
+(`org.gradle.caching=true`, `org.gradle.configuration-cache=true`,
+`org.gradle.configuration-cache.problems=warn`). All tasks benefit except
+`jib` / `jibDockerBuild` / `jibBuildTar`, which Jib 3.5.x marks
+`notCompatibleWithConfigurationCache` in `build.gradle` because the plugin
+captures `org.gradle.api.Project` in its configuration-time closures. This
+is tracked upstream in
+[GoogleContainerTools/jib#3132](https://github.com/GoogleContainerTools/jib/issues/3132);
+remove the workaround and re-test on every Jib upgrade.
+
 ## CI / GitHub Actions
 
 | Workflow | Trigger | Purpose |

--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,12 @@ test {
 	useJUnitPlatform()
 }
 
+// Resolve the project version to a String once, at configuration time, so
+// the Jib configuration closure can reference a plain String instead of
+// capturing the org.gradle.api.Project instance (which is not serializable
+// under the configuration cache).
+def imageVersion = version.toString()
+
 jib {
 	from {
 		image = 'eclipse-temurin:21-noble' // Noble = Ubuntu 24.04 LTS
@@ -157,7 +163,6 @@ jib {
 	to {
 		image = 'europe-docker.pkg.dev/dnsmonitor/containers/dns-client'
 
-		def imageVersion = project.version.toString()
 		tags = imageVersion.contains("-rc") ? ['latest'] : [imageVersion, 'latest']
 	}
 	container {
@@ -168,4 +173,17 @@ jib {
 		creationTime = 'USE_CURRENT_TIMESTAMP'
 	}
 	allowInsecureRegistries = false
+}
+
+// Jib 3.5.x captures the org.gradle.api.Project instance in its
+// configuration-time closures, which the configuration cache refuses to
+// serialise. Mark all Jib tasks as not configuration-cache compatible
+// until upstream fixes
+// https://github.com/GoogleContainerTools/jib/issues/3132 (open since
+// 2021, still unresolved in 3.5.4). Without this the build fails with
+// "Cannot invoke Project.getProjectDir() because this.project is null".
+// All other tasks still benefit from the configuration cache.
+tasks.withType(com.google.cloud.tools.jib.gradle.JibTask).configureEach {
+	notCompatibleWithConfigurationCache(
+		"https://github.com/GoogleContainerTools/jib/issues/3132")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.problems=warn


### PR DESCRIPTION
Enable `org.gradle.caching` and `org.gradle.configuration-cache` in a new `gradle.properties`. After this change, `./gradlew help`, `test`, and `build` serialise the task graph to the configuration cache and reuse it on subsequent runs.

### Changes

- **gradle.properties** (new): `org.gradle.caching=true`, `org.gradle.configuration-cache=true`, `org.gradle.configuration-cache.problems=warn`.
- **build.gradle**:
  - Hoist the Jib `imageVersion` resolution out of the `jib { to { } }` closure. The previous `project.version.toString()` inside the closure captured the `org.gradle.api.Project` instance and broke CC serialisation; the top-level `version` binding is used instead.
  - Mark `jib` / `jibDockerBuild` / `jibBuildTar` as `notCompatibleWithConfigurationCache`. Jib 3.5.x keeps a reference to the `Project` in its task and extension objects, which the CC refuses to serialise (see [GoogleContainerTools/jib#3132](https://github.com/GoogleContainerTools/jib/issues/3132), open since 2021, still unresolved in 3.5.4). The workaround is from the Jib issue thread itself. All non-Jib tasks still use the CC.
- **AGENTS.md**: new `Gradle build performance` section documenting the trade-off so the next Jib upgrade is not silently reverted.

### Verification

- `./gradlew help test build --configuration-cache`: `Configuration cache entry stored`, no problems.
- `./gradlew jib --no-configuration-cache`: fails the same way with and without CC (`registry-1.docker.io/library/eclipse-temurin` unreachable from this network); the failure is unrelated to the configuration cache.

Co-Authored-By: MiniMax-M3 <noreply@minimax.io>